### PR TITLE
--open-ai-model argument

### DIFF
--- a/chatgpt_voice_assistant/command_line_parser.py
+++ b/chatgpt_voice_assistant/command_line_parser.py
@@ -54,6 +54,12 @@ class CommandLineParser(OptionsParser):
             type=str,
         )
         parser.add_argument(
+            "--open-ai-model",
+            help=f"The Open AI model to use. See: https://platform.openai.com/docs/models/overview",
+            default="gpt-3.5-turbo",
+            type=str,
+        )
+        parser.add_argument(
             "--tts",
             choices=["apple", "google"],
             default="google",

--- a/chatgpt_voice_assistant/main.py
+++ b/chatgpt_voice_assistant/main.py
@@ -45,7 +45,11 @@ def main() -> None:
     listener: Listener = SpeechListener(input_device)
 
     # service to generate text given an input
-    text_generator: TextGenerator = OpenAITextGenerator(options.open_ai_key)
+    text_generator: TextGenerator = OpenAITextGenerator(
+        open_ai_key=options.open_ai_key, model=options.open_ai_model
+    )
+    if options.initial_prompt:
+        text_generator.generate_text(options.initial_prompt)
 
     # client to create speech from a given text
     text_to_speech_client: TextToSpeechClient

--- a/chatgpt_voice_assistant/models/command_line_arguments.py
+++ b/chatgpt_voice_assistant/models/command_line_arguments.py
@@ -9,6 +9,7 @@ class CommandLineArguments(NamedTuple):
     log_level: str
     max_tokens: int
     open_ai_key: str
+    open_ai_model: str
     safe_word: str
     speech_rate: float
     tld: str

--- a/chatgpt_voice_assistant/open_ai_text_generator.py
+++ b/chatgpt_voice_assistant/open_ai_text_generator.py
@@ -12,7 +12,7 @@ class OpenAITextGenerator(TextGenerator):
             raise TextGenerationError("Missing open_ai_key value parameter")
 
         self._open_ai_client = OpenAIClient(open_ai_key)
-        self._model = kwargs.get("model", "text-davinci-003")
+        self._model = kwargs.get("model", "gpt-3.5-turbo")
         self._max_tokens = kwargs.get("max_tokens", 200)
         self._temperature = kwargs.get("temperature", 0.7)
         self._previous_responses: list[Exchange] = kwargs.get("previous_responses", [])

--- a/tests/test_command_line_parser.py
+++ b/tests/test_command_line_parser.py
@@ -12,9 +12,8 @@ MOCK_COMMAND_LINE_ARGUMENTS: CommandLineArguments = CommandLineArguments(
     lang="en",
     tld="tld",
     open_ai_key="fake-key",
+    open_ai_model="gpt-3.5-turbo",
     safe_word="stop",
-    wake_word="robot",
-    max_tokens=100,
     speech_rate=1.0,
     tts="google",
 )
@@ -26,9 +25,8 @@ MOCK_COMMAND_LINE_ARGUMENTS_NO_API_KEY: CommandLineArguments = CommandLineArgume
     lang="en",
     tld="tld",
     open_ai_key=None,
+    open_ai_model="gpt-3.5-turbo",
     safe_word="stop",
-    wake_word="robot",
-    max_tokens=100,
     speech_rate=1.0,
     tts="google",
 )
@@ -100,6 +98,16 @@ def test_parse_returns_correct_open_ai_key(mock_arg_parser):
     command_line_parser = CommandLineParser()
     args: CommandLineArguments = command_line_parser.parse()
     assert args.open_ai_key == "fake-key"
+
+
+@patch(
+    "argparse.ArgumentParser.parse_args",
+    return_value=MOCK_COMMAND_LINE_ARGUMENTS,
+)
+def test_parse_returns_correct_open_ai_model(mock_arg_parser):
+    command_line_parser = CommandLineParser()
+    args: CommandLineArguments = command_line_parser.parse()
+    assert args.open_ai_model == "gpt-3.5-turbo"
 
 
 @patch(


### PR DESCRIPTION
"gpt-3.5-turbo performs at a similar capability to text-davinci-003 but at 10% the price per token,
[Open AI recommends] gpt-3.5-turbo for most use cases.
