### PR TITLE
Fix the problem that the key passed by the --open-ai-key parameter does not work for ChatCompletion

### DIFF
--- a/chatgpt_voice_assistant/clients/open_ai_client.py
+++ b/chatgpt_voice_assistant/clients/open_ai_client.py
@@ -47,7 +47,7 @@ class OpenAIClient:
             f"Sending prompt to chat completion endpoint: {json.dumps(messages)}"
         )
 
-        completion: ChatCompletion = openai.chat.completions.create(
+        completion: ChatCompletion = self._client.chat.completions.create(
             messages=messages,
             model=model,
             max_tokens=max_tokens,


### PR DESCRIPTION
ChatCompletion does not use an instance initialized with the OpenAIClient class, resulting in invalid parameters passed in the command line